### PR TITLE
addons: vxlan: support ToS and udpcsum

### DIFF
--- a/ifupdown2/lib/iproute2.py
+++ b/ifupdown2/lib/iproute2.py
@@ -306,7 +306,7 @@ class IPRoute2(Cache, Requirements):
         self.__update_cache_after_link_creation(ifname, "vxlan")
 
     def link_create_vxlan(self, name, vxlanid, localtunnelip=None, svcnodeip=None,
-                          remoteips=None, learning='on', ageing=None, ttl=None, physdev=None):
+                          remoteips=None, learning='on', ageing=None, ttl=None, physdev=None, udp_csum='on', tos = None):
         if svcnodeip and remoteips:
             raise Exception("svcnodeip and remoteip are mutually exclusive")
 
@@ -333,8 +333,14 @@ class IPRoute2(Cache, Requirements):
         if learning == 'off':
             cmd.append("nolearning")
 
+        if udp_csum == 'off':
+            cmd.append("noudpcsum")
+
         if ttl is not None:
             cmd.append("ttl %s" % ttl)
+
+        if tos is not None:
+            cmd.append("tos %s" % tos)
 
         if physdev:
             cmd.append("dev %s" % physdev)

--- a/ifupdown2/lib/nlcache.py
+++ b/ifupdown2/lib/nlcache.py
@@ -2966,6 +2966,10 @@ class NetlinkListenerWithCache(nllistener.NetlinkManagerWithListener, BaseObject
                     cmd.append("nolearning")
                 info_data[nlpacket.Link.IFLA_VXLAN_LEARNING] = int(learning)
 
+                if not udp_csum:
+                    cmd.append("noudpcsum")
+                info_data[nlpacket.Link.IFLA_VXLAN_UDP_CSUM] = int(udp_csum)
+
                 if physdev:
                     cmd.append("dev %s" % physdev)
                     info_data[nlpacket.Link.IFLA_VXLAN_LINK] = self.cache.get_ifindex(physdev)

--- a/ifupdown2/nlmanager/nlmanager.py
+++ b/ifupdown2/nlmanager/nlmanager.py
@@ -1015,7 +1015,7 @@ class NetlinkManager(object):
         return self.tx_nlpacket_get_response(nbr)
 
     def link_add_vxlan(self, ifname, vxlanid, dstport=None, local=None,
-                       group=None, learning=True, ageing=None, physdev=None, ttl=None):
+                       group=None, learning=True, ageing=None, physdev=None, ttl=None, tos=None, udp_csum=True):
 
         debug = RTM_NEWLINK in self.debug
 
@@ -1026,7 +1026,10 @@ class NetlinkManager(object):
             info_data[Link.IFLA_VXLAN_LOCAL] = local
         if group:
             info_data[Link.IFLA_VXLAN_GROUP] = group
-
+        if tos:
+            info_data[Link.IFLA_VXLAN_TOS] = int(tos)
+        
+        info_data[Link.IFLA_VXLAN_UDP_CSUM] = int(udp_csum)
         info_data[Link.IFLA_VXLAN_LEARNING] = int(learning)
         info_data[Link.IFLA_VXLAN_TTL] = ttl
 


### PR DESCRIPTION
Opening this PR against our fork to stage it, when we're happy with it we should retarget to CumulusNetworks/ifupdown2.
```
≽ sudo ip link delete dev potato ; sudo python ifreload --all ; ip -d link show potato
64: potato: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether ee:d3:ac:db:ba:65 brd ff:ff:ff:ff:ff:ff promiscuity 0 minmtu 68 maxmtu 65535
    vxlan id 1947 local 127.0.0.1 srcport 0 0 dstport 4789 **tos 0x12** ttl auto ageing 300 **noudpcsum** noudp6zerocsumtx noudp6zerocsumrx addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
```

```
auto potato
iface potato
    vxlan-id 1947
    vxlan-tos 18
    vxlan-udp-csum no
```
