### PR TITLE
Support validation an attribute as allow-list or range

### DIFF
--- a/ifupdown2/addons/vxlan.py
+++ b/ifupdown2/addons/vxlan.py
@@ -97,12 +97,14 @@ class vxlan(Addon, moduleBase):
                 "help": "specifies the TTL value to use in outgoing packets "
                         "(range 0..255), 0=auto",
                 "default": "0",
-                "validvals": ["0", "255"],
+                "validvals": ["auto"],
+                "validrange": ["0", "255"],
                 "example": ['vxlan-ttl 42'],
             },
             "vxlan-tos": {
                 "help": "specifies the ToS value (range 0..255), 1=inherit",
-                "validvals": ["inherit", "0", "255"],
+                "validvals": ["inherit"],
+                "validrange": ["0", "255"],
                 "example": ['vxlan-tos 42'],
             },
             "vxlan-mcastgrp": {
@@ -235,13 +237,12 @@ class vxlan(Addon, moduleBase):
         return purge_remotes
 
     def get_vxlan_ttl_from_string(self, ttl_config):
-        ttl = 0
         if ttl_config:
             if ttl_config.lower() == "auto":
-                ttl = 0
+                return 0
             else:
-                ttl = int(ttl_config)
-        return ttl
+                return int(ttl_config)
+        return None
 
     def get_vxlan_tos_from_string(self, tos_config):
         if tos_config:

--- a/ifupdown2/ifupdown/ifupdownmain.py
+++ b/ifupdown2/ifupdown/ifupdownmain.py
@@ -1240,37 +1240,43 @@ class ifupdownMain:
         return keyword_found
 
     def _check_validvals_value(self, attrname, value, validvals, validrange):
-        if validvals and value not in validvals:
-            is_valid = False
-            for keyword in validvals:
-                if self._is_keyword(keyword):
+        errors = []
+        if validvals:
+            if value in validvals:
+                # Our value is one of the specified validvals.  We're good.
+                return {'result': True}
+            else:
+                # It's not in the list, but let's check if we have a keyword.
+                for keyword in filter(self._is_keyword, validvals):
+                    # If we do, validate the value using the validator for that keyword
                     if validrange:
                         if self.validate_keywords[keyword](value, validrange):
                             return {'result': True}
                     else:
                         if self.validate_keywords[keyword](value):
                             return {'result': True}
-            if not is_valid:
-                return {
-                    'result': False,
-                    'message': 'invalid value "%s": valid attribute values: %s'
-                               % (value, validvals)
-                }
-        elif validvals and value in validvals:
-            pass
-        elif validrange:
+
+                # If we checked all keywords and didn't return, we didn't pass with validvals.  Save the error.
+                errors.append('valid attribute values: %s' % validvals)
+
+        if validrange:
+            # If we didn't return from validvals (either because there are no validvals
+            # or because we didn't pass there), move on to checking validrange.
             if len(validrange) != 2:
                 raise Exception('%s: invalid range in addon configuration'
                                 % '-'.join(validrange))
-            _value = int(value)
-            if _value < int(validrange[0]) or _value > int(validrange[1]):
-                return {
-                    'result': False,
-                    'message': 'value of out range "%s": '
-                               'valid attribute range: %s'
-                               % (value, '-'.join(validrange))
-                }
-        return {'result': True}
+            if int(validrange[0]) <= int(value) <= int(validrange[1]):
+                # Our value is in the range.  We're good.
+                return {'result': True}
+            else:
+                # It's not in the range, we didn't pass with validrange.  Save the error.
+                errors.append('valid attribute range: %s' % '-'.join(validrange))
+
+        # If we got here, either we have errors or we don't have any validvals or validrange.
+        if len(errors) > 0:
+            return {'result': False, 'message': 'invalid value %s: %s' % (value, ", ".join(errors))}
+        else:
+            return {'result': True}
 
     def _check_validvals(self, ifacename, module_name, attrs):
         ifaceobj = self.get_ifaceobjs(ifacename)


### PR DESCRIPTION
This allows fields like vxlan-tos and vxlan-ttl to syntax-check both
named values (like 'inherit' and 'auto') and numeric values (0-255, in
both cases).  Without this behavior, numeric values within the range
are passed to netlink and handled correctly, but fail a --syntax-check
because, for instance, "64" is not "inherit", "0", or "255":
invalid value "64": valid attribute values: ['0', '255']
info: exit status 1